### PR TITLE
Add binary file diffs, rendered/raw toggle, and rendering optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 .vscode/
 
 resources/
+**/.DS_Store

--- a/src/abstract_diff_view.ts
+++ b/src/abstract_diff_view.ts
@@ -46,6 +46,8 @@ export default abstract class DiffView extends Modal {
 			diffStyle: this.plugin.settings.diffStyle,
 			matchWordsThreshold: this.plugin.settings.matchWordsThreshold,
 			outputFormat: this.plugin.settings.outputFormat,
+			matching: 'none' as const,
+			drawFileList: false,
 		};
 		this.containerEl.addClass('diff');
 		this.syncHistoryContentContainer = this.contentEl.createDiv({
@@ -292,7 +294,10 @@ export default abstract class DiffView extends Modal {
 				});
 			}
 			const diffContainer = this.diffContentEl.createDiv();
-			diffContainer.innerHTML = this.getDiff();
+			// Defer heavy synchronous diff computation to yield to browser paint
+			setTimeout(() => {
+				diffContainer.innerHTML = this.getDiff();
+			}, 0);
 		} else {
 			const decoder = new TextDecoder('utf-8');
 			const leftStr =

--- a/src/abstract_diff_view.ts
+++ b/src/abstract_diff_view.ts
@@ -1,6 +1,6 @@
-import { createTwoFilesPatch } from 'diff';
+import { createTwoFilesPatch, diffArrays } from 'diff';
 import { Diff2HtmlConfig, html } from 'diff2html';
-import { App, Modal, sanitizeHTMLToDom, TFile } from 'obsidian';
+import { App, Modal, TFile, Component, MarkdownRenderer } from 'obsidian';
 import FileModal from './file_modal';
 import type { vItem } from './interfaces';
 import type OpenSyncHistoryPlugin from './main';
@@ -13,13 +13,17 @@ export default abstract class DiffView extends Modal {
 	rightVList: vItem[];
 	leftActive: number;
 	rightActive: number;
-	rightContent: string;
-	leftContent: string;
+	rightContent: string | Uint8Array;
+	leftContent: string | Uint8Array;
 	syncHistoryContentContainer: HTMLElement;
+	diffContentEl: HTMLElement;
 	leftHistory: HTMLElement[];
 	rightHistory: HTMLElement[];
 	htmlConfig: Diff2HtmlConfig;
 	ids: { left: number; right: number };
+	comp: Component;
+	viewMode: 'raw' | 'rendered';
+	private blobUrls: string[] = [];
 
 	constructor(plugin: OpenSyncHistoryPlugin, app: App, file: TFile) {
 		super(app);
@@ -44,17 +48,23 @@ export default abstract class DiffView extends Modal {
 			outputFormat: this.plugin.settings.outputFormat,
 		};
 		this.containerEl.addClass('diff');
-		// @ts-ignore
 		this.syncHistoryContentContainer = this.contentEl.createDiv({
 			cls: ['sync-history-content-container', 'diff'],
 		});
 		if (this.plugin.settings.colorBlind) {
 			this.syncHistoryContentContainer.addClass('colorblind');
 		}
+		this.viewMode = 'rendered';
+		this.comp = new Component();
+		this.comp.load();
+		this.diffContentEl = this.syncHistoryContentContainer.createDiv({
+			cls: 'diff-content-container-inner',
+		});
 	}
 
 	onOpen() {
 		super.onOpen();
+		this.createToggleBar();
 		// in onOpen() of the child classes these calls need to be implemented
 
 		// initial versions are different
@@ -81,14 +91,88 @@ export default abstract class DiffView extends Modal {
 
 	abstract appendVersions(): void;
 
+	protected isBinaryFile(): boolean {
+		return this.plugin.diff_utils.isBinaryFile(this.file.name);
+	}
+
+	protected getBinaryPreview(): string {
+		const toUint8Array = (
+			content: string | Uint8Array | ArrayBuffer
+		): Uint8Array => {
+			if (content instanceof Uint8Array) return content;
+			if (content instanceof ArrayBuffer) return new Uint8Array(content);
+			if (typeof content === 'string')
+				return new TextEncoder().encode(content);
+			return new Uint8Array();
+		};
+
+		const leftUint8 = toUint8Array(this.leftContent);
+		const rightUint8 = toUint8Array(this.rightContent);
+
+		const isImage = [
+			'png',
+			'jpg',
+			'jpeg',
+			'gif',
+			'bmp',
+			'webp',
+		].includes(this.file.extension.toLowerCase());
+
+		if (isImage) {
+			const leftBlob = new Blob([leftUint8 as BlobPart]);
+			const rightBlob = new Blob([rightUint8 as BlobPart]);
+			const leftUrl = URL.createObjectURL(leftBlob);
+			const rightUrl = URL.createObjectURL(rightBlob);
+			this.blobUrls.push(leftUrl, rightUrl);
+
+			return `<div class="binary-diff">
+				<div class="binary-side">
+					<h4>Old Version</h4>
+					<img src="${leftUrl}" style="max-width: 100%;" />
+				</div>
+				<div class="binary-side">
+					<h4>New Version</h4>
+					<img src="${rightUrl}" style="max-width: 100%;" />
+				</div>
+			</div>`;
+		} else {
+			return `<div class="binary-diff">
+				<div class="binary-side">
+					<h4>Old Version</h4>
+					<div class="binary-fallback-msg">Visual diff not available for this binary format.</div>
+					<div class="u-muted">Size: ${(leftUint8.length / 1024).toFixed(2)} KB</div>
+				</div>
+				<div class="binary-side">
+					<h4>New Version</h4>
+					<div class="binary-fallback-msg">Visual diff not available for this binary format.</div>
+					<div class="u-muted">Size: ${(rightUint8.length / 1024).toFixed(2)} KB</div>
+				</div>
+			</div>`;
+		}
+	}
+
 	public getDiff(): string {
+		if (this.isBinaryFile()) {
+			return this.getBinaryPreview();
+		}
+
+		const decoder = new TextDecoder('utf-8');
+		const leftStr =
+			this.leftContent instanceof Uint8Array
+				? decoder.decode(this.leftContent)
+				: this.leftContent;
+		const rightStr =
+			this.rightContent instanceof Uint8Array
+				? decoder.decode(this.rightContent)
+				: this.rightContent;
+
 		// the second type is needed for the Git view, it reimplements getDiff
 		// get diff
 		const uDiff = createTwoFilesPatch(
 			this.file.basename,
 			this.file.basename,
-			this.leftContent,
-			this.rightContent
+			leftStr as string,
+			rightStr as string
 		);
 
 		// create HTML from diff
@@ -104,7 +188,7 @@ export default abstract class DiffView extends Modal {
 
 	private createHistory(
 		el: HTMLElement,
-		left: boolean = false,
+		left = false,
 		warning: string
 	): HTMLElement[] {
 		const syncHistoryListContainer = el.createDiv({
@@ -131,17 +215,266 @@ export default abstract class DiffView extends Modal {
 		return [syncHistoryListContainer, syncHistoryList];
 	}
 
-	public basicHtml(diff: string, diffType: string): void {
+	onClose() {
+		super.onClose();
+		this.blobUrls.forEach((url) => URL.revokeObjectURL(url));
+		this.comp.unload();
+	}
+
+	private createToggleBar(): void {
+		if (this.isBinaryFile()) {
+			return;
+		}
+
+		const toggleBar = this.syncHistoryContentContainer.createDiv({
+			cls: 'diff-toggle-bar',
+		});
+
+		const rawButton = toggleBar.createEl('button', {
+			cls: ['diff-toggle-btn'],
+			text: 'Raw Diff',
+		});
+
+		const renderButton = toggleBar.createEl('button', {
+			cls: ['diff-toggle-btn', 'is-active'],
+			text: 'Rendered',
+		});
+
+		rawButton.addEventListener('click', () => {
+			if (this.viewMode !== 'raw') {
+				this.viewMode = 'raw';
+				rawButton.addClass('is-active');
+				renderButton.removeClass('is-active');
+				this.updateDiffView();
+			}
+		});
+
+		renderButton.addEventListener('click', () => {
+			if (this.viewMode !== 'rendered') {
+				this.viewMode = 'rendered';
+				renderButton.addClass('is-active');
+				rawButton.removeClass('is-active');
+				this.updateDiffView();
+			}
+		});
+	}
+
+	public async updateDiffView(): Promise<void> {
+		this.diffContentEl.empty();
+		this.blobUrls.forEach((url) => URL.revokeObjectURL(url));
+		this.blobUrls = [];
+
+		if (this.isBinaryFile()) {
+			this.diffContentEl.innerHTML = this.getDiff();
+			return;
+		}
+
+		if (this.viewMode === 'raw') {
+			const rawHeader = this.diffContentEl.createDiv({
+				cls: 'raw-diff-header',
+				attr: { style: 'display: flex; gap: 1.5rem; padding: 0 1.5rem; margin-bottom: 1rem;' },
+			});
+			if (this.htmlConfig.outputFormat === 'side-by-side') {
+				const leftSide = rawHeader.createDiv({ attr: { style: 'flex: 1;' } });
+				leftSide.createEl('h4', {
+					text: 'Old Version (Raw)',
+					attr: { style: 'margin: 0; font-weight: 600; color: var(--text-normal);' },
+				});
+				const rightSide = rawHeader.createDiv({ attr: { style: 'flex: 1;' } });
+				rightSide.createEl('h4', {
+					text: 'New Version (Raw)',
+					attr: { style: 'margin: 0; font-weight: 600; color: var(--text-normal);' },
+				});
+			} else {
+				rawHeader.createEl('h4', {
+					text: 'Raw Diff',
+					attr: { style: 'margin: 0; font-weight: 600; color: var(--text-normal);' },
+				});
+			}
+			const diffContainer = this.diffContentEl.createDiv();
+			diffContainer.innerHTML = this.getDiff();
+		} else {
+			const decoder = new TextDecoder('utf-8');
+			const leftStr =
+				this.leftContent instanceof Uint8Array
+					? decoder.decode(this.leftContent)
+					: this.leftContent;
+			const rightStr =
+				this.rightContent instanceof Uint8Array
+					? decoder.decode(this.rightContent)
+					: this.rightContent;
+
+			// Render both markdowns to temporary containers
+			const tempLeftDiv = document.createElement('div');
+			const tempRightDiv = document.createElement('div');
+
+			await MarkdownRenderer.render(
+				this.app,
+				leftStr,
+				tempLeftDiv,
+				this.file.path,
+				this.comp
+			);
+
+			await MarkdownRenderer.render(
+				this.app,
+				rightStr,
+				tempRightDiv,
+				this.file.path,
+				this.comp
+			);
+
+			const leftHtml = tempLeftDiv.innerHTML;
+			const rightHtml = tempRightDiv.innerHTML;
+
+			// Tokenize HTML: keep tags intact, split text into words/whitespace/punctuation
+			const tokenizeHtml = (htmlStr: string): string[] => {
+				const tokens: string[] = [];
+				const regex = /(<[^>]+>|[^<]+)/g;
+				let match;
+				while ((match = regex.exec(htmlStr)) !== null) {
+					const token = match[0];
+					if (token.startsWith('<')) {
+						tokens.push(token);
+					} else {
+						const textRegex = /(\w+|[^\w\s]+|\s+)/g;
+						let textMatch;
+						while ((textMatch = textRegex.exec(token)) !== null) {
+							tokens.push(textMatch[0]);
+						}
+					}
+				}
+				return tokens;
+			};
+
+			const leftTokens = tokenizeHtml(leftHtml);
+			const rightTokens = tokenizeHtml(rightHtml);
+
+			const diffResult = diffArrays(leftTokens, rightTokens);
+
+			const addClassToTag = (tag: string, className: string): string => {
+				if (tag.startsWith('</')) {
+					return tag;
+				}
+				const classMatch = tag.match(/class=["']([^"']*)["']/);
+				if (classMatch) {
+					const existingClasses = classMatch[1];
+					const newClasses = existingClasses
+						? `${existingClasses} ${className}`
+						: className;
+					return tag.replace(
+						/class=["']([^"']*)["']/,
+						`class="${newClasses}"`
+					);
+				} else {
+					const tagNameMatch = tag.match(/^<\w+/);
+					if (tagNameMatch) {
+						const tagName = tagNameMatch[0];
+						return tag.replace(
+							tagName,
+							`${tagName} class="${className}"`
+						);
+					}
+				}
+				return tag;
+			};
+
+			const leftDiffHtmlParts: string[] = [];
+			const rightDiffHtmlParts: string[] = [];
+
+			for (const change of diffResult) {
+				if (change.added) {
+					for (const token of change.value) {
+						if (token.startsWith('<')) {
+							rightDiffHtmlParts.push(
+								addClassToTag(token, 'diff-rendered-added')
+							);
+						} else {
+							rightDiffHtmlParts.push(
+								`<ins class="diff-rendered-added">${token}</ins>`
+							);
+						}
+					}
+				} else if (change.removed) {
+					for (const token of change.value) {
+						if (token.startsWith('<')) {
+							leftDiffHtmlParts.push(
+								addClassToTag(token, 'diff-rendered-deleted')
+							);
+						} else {
+							leftDiffHtmlParts.push(
+								`<del class="diff-rendered-deleted">${token}</del>`
+							);
+						}
+					}
+				} else {
+					for (const token of change.value) {
+						leftDiffHtmlParts.push(token);
+						rightDiffHtmlParts.push(token);
+					}
+				}
+			}
+
+			const finalLeftHtml = leftDiffHtmlParts.join('');
+			const finalRightHtml = rightDiffHtmlParts.join('');
+
+			const renderedContainer = this.diffContentEl.createDiv({
+				cls: 'markdown-rendered-diff',
+			});
+
+			const leftSide = renderedContainer.createDiv({
+				cls: 'markdown-side',
+			});
+			leftSide.createEl('h4', { text: 'Old Version (Rendered)' });
+			const leftContentEl = leftSide.createDiv({
+				cls: 'rendered-content',
+			});
+			leftContentEl.innerHTML = finalLeftHtml;
+
+			const rightSide = renderedContainer.createDiv({
+				cls: 'markdown-side',
+			});
+			rightSide.createEl('h4', { text: 'New Version (Rendered)' });
+			const rightContentEl = rightSide.createDiv({
+				cls: 'rendered-content',
+			});
+			rightContentEl.innerHTML = finalRightHtml;
+
+			let scrollLocked = false;
+			leftSide.addEventListener('scroll', () => {
+				if (!scrollLocked) {
+					scrollLocked = true;
+					rightSide.scrollTop = leftSide.scrollTop;
+					rightSide.scrollLeft = leftSide.scrollLeft;
+					requestAnimationFrame(() => {
+						scrollLocked = false;
+					});
+				}
+			});
+
+			rightSide.addEventListener('scroll', () => {
+				if (!scrollLocked) {
+					scrollLocked = true;
+					leftSide.scrollTop = rightSide.scrollTop;
+					leftSide.scrollLeft = rightSide.scrollLeft;
+					requestAnimationFrame(() => {
+						scrollLocked = false;
+					});
+				}
+			});
+		}
+	}
+
+	public async basicHtml(diffType: string): Promise<void> {
 		// set title
 		this.titleEl.setText(diffType);
-		// add diff to container
-		const goodHTML = sanitizeHTMLToDom(diff)
-		this.syncHistoryContentContainer.replaceChildren(goodHTML);
 
 		// add history lists and diff to DOM
 		this.contentEl.appendChild(this.leftHistory[0]);
 		this.contentEl.appendChild(this.syncHistoryContentContainer);
 		this.contentEl.appendChild(this.rightHistory[0]);
+
+		await this.updateDiffView();
 	}
 
 	public makeMoreGeneralHtml(): void {
@@ -157,7 +490,7 @@ export default abstract class DiffView extends Modal {
 		div: HTMLDivElement,
 		currentVList: vItem[],
 		currentActive: number,
-		left: boolean = false
+		left = false
 	): Promise<vItem> {
 		// the exact return type depends on the type of currentVList, it is either vSyncItem or vRecoveryItem
 		// formerly active left/right version

--- a/src/diff_utils.ts
+++ b/src/diff_utils.ts
@@ -21,13 +21,26 @@ export default class DiffUtils {
 		return await this.instance.getHistory(file.path, uid);
 	}
 
-	async getContent(uid: number): Promise<string> {
+	async getContent(uid: number): Promise<Uint8Array> {
 		const content =
 			await this.app.internalPlugins.plugins.sync.instance.getContentForVersion(
 				uid
 			);
-		const textDecoder = new TextDecoder('utf-8');
-		const text = textDecoder.decode(new Uint8Array(content));
-		return text;
+		return new Uint8Array(content);
+	}
+
+	isBinaryFile(filename: string): boolean {
+		const extension = filename.split('.').pop()?.toLowerCase() || '';
+		const binaryExtensions = [
+			'png',
+			'jpg',
+			'jpeg',
+			'gif',
+			'bmp',
+			'webp',
+			'pdf',
+			'zip',
+		];
+		return binaryExtensions.includes(extension);
 	}
 }

--- a/src/diff_view.ts
+++ b/src/diff_view.ts
@@ -1,4 +1,4 @@
-import { App, Notice, sanitizeHTMLToDom, TFile } from 'obsidian';
+import { App, Notice, TFile } from 'obsidian';
 import type {
 	gHResult,
 	vSyncItem,
@@ -31,10 +31,9 @@ export default class SyncDiffView extends DiffView {
 	async onOpen() {
 		super.onOpen();
 		await this.getInitialVersions();
-		const diff = this.getDiff() as string;
 		this.makeHistoryLists(SYNC_WARNING);
 		this.makeButtons();
-		this.basicHtml(diff, 'Sync Diff');
+		await this.basicHtml('Sync Diff');
 		this.appendVersions();
 		this.makeMoreGeneralHtml();
 	}
@@ -54,13 +53,10 @@ export default class SyncDiffView extends DiffView {
 			return;
 		}
 
-		// get function
-		const getContent = this.plugin.diff_utils.getContent.bind(this);
-
 		// choose two latest versions
 		[this.leftContent, this.rightContent] = [
-			await getContent(secondLatestV),
-			await getContent(latestV),
+			await this.plugin.diff_utils.getContent(secondLatestV),
+			await this.plugin.diff_utils.getContent(latestV),
 		];
 	}
 
@@ -142,7 +138,7 @@ export default class SyncDiffView extends DiffView {
 	): vSyncItem[] {
 		const versionList: vSyncItem[] = [];
 		for (let i = 0; i <= versions.items.length - 1; i++) {
-			let version = versions.items[i];
+			const version = versions.items[i];
 			const date = new Date(version.ts);
 			const div = el.createDiv({
 				cls: ITEM_CLASS,
@@ -152,7 +148,7 @@ export default class SyncDiffView extends DiffView {
 				},
 			});
 			left ? (this.ids.left += 1) : (this.ids.right += 1);
-			const infoDiv = div.createDiv({
+			div.createDiv({
 				cls: ['u-muted'],
 				text: getSize(version.size) + ' KB [' + version.device + ']',
 			});
@@ -169,8 +165,7 @@ export default class SyncDiffView extends DiffView {
 						left
 					)) as vSyncItem;
 					await this.getSyncContent(clickedEl, left);
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(this.getDiff() as string));
+					await this.updateDiffView();
 				} else {
 					const clickedEl = (await this.generateVersionListener(
 						div,
@@ -178,21 +173,19 @@ export default class SyncDiffView extends DiffView {
 						this.rightActive
 					)) as vSyncItem;
 					await this.getSyncContent(clickedEl);
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(this.getDiff() as string));
+					await this.updateDiffView();
 				}
 			});
 		}
 		return versionList;
 	}
 
-	private async getSyncContent(clickedEl: vSyncItem, left: boolean = false) {
+	private async getSyncContent(clickedEl: vSyncItem, left = false) {
 		// get the content for the clicked HTML element
-		const getContent = this.plugin.diff_utils.getContent.bind(this);
 		if (left) {
-			this.leftContent = await getContent(clickedEl.v.uid);
+			this.leftContent = await this.plugin.diff_utils.getContent(clickedEl.v.uid);
 		} else {
-			this.rightContent = await getContent(clickedEl.v.uid);
+			this.rightContent = await this.plugin.diff_utils.getContent(clickedEl.v.uid);
 		}
 	}
 }

--- a/src/file_modal.ts
+++ b/src/file_modal.ts
@@ -12,11 +12,12 @@ import type OpenSyncHistoryPlugin from './main';
 export default class FileModal extends Modal {
 	raw: boolean;
 	comp: Component;
+	private blobUrl: string | null = null;
 
 	constructor(
 		private plugin: OpenSyncHistoryPlugin,
 		public app: App,
-		private syncFile: string,
+		private syncFile: string | Uint8Array,
 		private file: TFile,
 		private warning: string
 	) {
@@ -31,13 +32,16 @@ export default class FileModal extends Modal {
 	}
 
 	async onClose() {
+		if (this.blobUrl) {
+			URL.revokeObjectURL(this.blobUrl);
+		}
 		this.comp.unload();
 	}
 
 	async onOpen() {
 		this.containerEl.addClass('version-display');
 
-		const warning = this.contentEl.createDiv({
+		this.contentEl.createDiv({
 			text: this.warning,
 		});
 		this.contentEl.createEl('br');
@@ -56,48 +60,60 @@ export default class FileModal extends Modal {
 
 		const el = this.contentEl.createDiv();
 
-		switchButton.addEventListener('click', () => {
-			if (!this.raw) {
-				el.empty();
-				const textArea = el.createEl('textarea', {
-					text: this.syncFile,
-					attr: { spellcheck: false },
-					cls: 'plain-text-area',
-				});
-				this.raw = !this.raw;
-				switchButton.innerText = 'Show Reading view';
-			} else {
-				this.raw = !this.raw;
-				(async () => {
+		if (this.syncFile instanceof Uint8Array) {
+			const blob = new Blob([this.syncFile]);
+			this.blobUrl = URL.createObjectURL(blob);
+			el.createEl('img', {
+				attr: { src: this.blobUrl, style: 'max-width: 100%;' },
+			});
+			switchButton.hide();
+		} else {
+			switchButton.addEventListener('click', () => {
+				if (!this.raw) {
 					el.empty();
-					await MarkdownRenderer.render(
-						this.app,
-						this.syncFile,
-						el,
-						this.file.path,
-						this.comp
+					el.createEl('textarea', {
+						text: this.syncFile as string,
+						attr: { spellcheck: false },
+						cls: 'plain-text-area',
+					});
+					this.raw = !this.raw;
+					switchButton.innerText = 'Show Reading view';
+				} else {
+					this.raw = !this.raw;
+					(async () => {
+						el.empty();
+						await MarkdownRenderer.render(
+							this.app,
+							this.syncFile as string,
+							el,
+							this.file.path,
+							this.comp
+						);
+					})();
+					switchButton.innerText = 'Show raw text';
+				}
+			});
+
+			restoreButton.addEventListener('click', () => {
+				(async () => {
+					await this.app.vault.modify(
+						this.file,
+						this.syncFile as string
 					);
 				})();
-				switchButton.innerText = 'Show raw text';
-			}
-		});
+				new Notice(
+					`The ${this.file.basename} file has been overwritten with the selected version.`
+				);
+				this.close();
+			});
 
-		restoreButton.addEventListener('click', () => {
-			(async () => {
-				await this.app.vault.modify(this.file, this.syncFile);
-			})();
-			new Notice(
-				`The ${this.file.basename} file has been overwritten with the selected version.`
+			await MarkdownRenderer.render(
+				this.app,
+				this.syncFile as string,
+				el,
+				this.file.path,
+				this.comp
 			);
-			this.close();
-		});
-
-		await MarkdownRenderer.render(
-			this.app,
-			this.syncFile,
-			el,
-			this.file.path,
-			this.comp
-		);
+		}
 	}
 }

--- a/src/git_diff_view.ts
+++ b/src/git_diff_view.ts
@@ -1,4 +1,4 @@
-import { App, Notice, sanitizeHTMLToDom, setTooltip, TFile } from 'obsidian';
+import { App, Notice, setTooltip, TFile } from 'obsidian';
 import DiffView from './abstract_diff_view';
 import { GIT_WARNING, ITEM_CLASS } from './constants';
 import type { DefaultLogFields, vGitItem } from './interfaces';
@@ -22,9 +22,8 @@ export default class GitDiffView extends DiffView {
 		if (versions === false) {
 			return;
 		}
-		const diff = this.getDiff();
 		this.makeHistoryLists(GIT_WARNING);
-		this.basicHtml(diff, 'Git Diff');
+		await this.basicHtml('Git Diff');
 		this.appendVersions();
 		this.makeMoreGeneralHtml();
 	}
@@ -49,11 +48,22 @@ export default class GitDiffView extends DiffView {
 			fileName: this.file.name,
 		});
 		this.versions.push(...gitVersions);
-		const diskContent = await this.app.vault.read(this.file);
-		const latestCommit = await gitManager.show(
-			this.versions[1].hash,
-			this.file.path
-		);
+		const diskContent = this.isBinaryFile()
+			? new Uint8Array(await this.app.vault.readBinary(this.file))
+			: await this.app.vault.read(this.file);
+		let latestCommit: string | Uint8Array;
+		if (this.isBinaryFile()) {
+			latestCommit = new Uint8Array(
+				await gitManager.git.binaryCatFile([
+					`${this.versions[1].hash}:${this.file.path}`,
+				])
+			);
+		} else {
+			latestCommit = await gitManager.show(
+				this.versions[1].hash,
+				this.file.path
+			);
+		}
 		[this.leftContent, this.rightContent] = [latestCommit, diskContent];
 	}
 
@@ -73,7 +83,7 @@ export default class GitDiffView extends DiffView {
 	appendGitVersions(
 		el: HTMLElement,
 		versions: DefaultLogFields[],
-		left: boolean = false
+		left = false
 	): vGitItem[] {
 		const versionList: vGitItem[] = [];
 		for (let i = 0; i < versions.length; i++) {
@@ -95,17 +105,17 @@ export default class GitDiffView extends DiffView {
 				cls: ['u-muted'],
 			});
 			if (version.fileName !== this.file.path && i !== 0) {
-				const changedName = infoDiv.createDiv({
+				infoDiv.createDiv({
 					text: 'Old name: ' + version.fileName.slice(0, -3),
 				});
 			}
-			const date = infoDiv.createDiv({
+			infoDiv.createDiv({
 				text: version.date.split('T')[0],
 			});
-			const time = infoDiv.createDiv({
+			infoDiv.createDiv({
 				text: version.date.split('T')[1],
 			});
-			const author = infoDiv.createDiv({
+			infoDiv.createDiv({
 				text: version.author_name,
 			});
 			const hash = infoDiv.createDiv({
@@ -115,10 +125,9 @@ export default class GitDiffView extends DiffView {
 					'aria-label-position': 'bottom'
 				}*/
 			});
-			let refs;
 			const refsText = version.refs;
 			if (refsText !== '') {
-				refs = infoDiv.createDiv({
+				infoDiv.createDiv({
 					text: refsText,
 				});
 			}
@@ -138,6 +147,9 @@ export default class GitDiffView extends DiffView {
 				v: version,
 			});
 			div.addEventListener('click', async () => {
+				const isBinary = this.isBinaryFile();
+				const gitManager =
+					this.app.plugins.plugins['obsidian-git'].gitManager;
 				if (left) {
 					const clickedEl = (await this.generateVersionListener(
 						div,
@@ -146,17 +158,30 @@ export default class GitDiffView extends DiffView {
 						left
 					)) as vGitItem;
 					if (this.leftActive === 0) {
-						this.leftContent = await this.app.vault.read(this.file);
+						if (isBinary) {
+							this.leftContent = new Uint8Array(
+								await this.app.vault.readBinary(this.file)
+							);
+						} else {
+							this.leftContent = await this.app.vault.read(
+								this.file
+							);
+						}
 					} else {
-						this.leftContent = await this.app.plugins.plugins[
-							'obsidian-git'
-						].gitManager.show(
-							clickedEl.v.hash,
-							clickedEl.v.fileName
-						);
+						if (isBinary) {
+							this.leftContent = new Uint8Array(
+								await gitManager.git.binaryCatFile([
+									`${clickedEl.v.hash}:${clickedEl.v.fileName}`,
+								])
+							);
+						} else {
+							this.leftContent = await gitManager.show(
+								clickedEl.v.hash,
+								clickedEl.v.fileName
+							);
+						}
 					}
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(await this.getDiff()));
+					await this.updateDiffView();
 				} else {
 					const clickedEl = (await this.generateVersionListener(
 						div,
@@ -164,19 +189,30 @@ export default class GitDiffView extends DiffView {
 						this.rightActive
 					)) as vGitItem;
 					if (this.rightActive === 0) {
-						this.rightContent = await this.app.vault.read(
-							this.file
-						);
+						if (isBinary) {
+							this.rightContent = new Uint8Array(
+								await this.app.vault.readBinary(this.file)
+							);
+						} else {
+							this.rightContent = await this.app.vault.read(
+								this.file
+							);
+						}
 					} else {
-						this.rightContent = await this.app.plugins.plugins[
-							'obsidian-git'
-						].gitManager.show(
-							clickedEl.v.hash,
-							clickedEl.v.fileName
-						);
+						if (isBinary) {
+							this.rightContent = new Uint8Array(
+								await gitManager.git.binaryCatFile([
+									`${clickedEl.v.hash}:${clickedEl.v.fileName}`,
+								])
+							);
+						} else {
+							this.rightContent = await gitManager.show(
+								clickedEl.v.hash,
+								clickedEl.v.fileName
+							);
+						}
 					}
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(await this.getDiff()));
+					await this.updateDiffView();
 				}
 			});
 		}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,7 @@
+declare module 'hogan.js' {
+	export class Template {}
+	export class Context {}
+	export interface Partials {
+		[key: string]: Template;
+	}
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -35,6 +35,9 @@ declare module 'obsidian' {
 						): Promise<string>;
 						git: {
 							diff(options: string[]): Promise<string>;
+							binaryCatFile(
+								options: string[]
+							): Promise<Uint8Array>;
 						};
 					};
 				};
@@ -72,7 +75,7 @@ export interface item {
 export interface recResult {
 	path: string;
 	ts: number;
-	data: string;
+	data: string | ArrayBuffer;
 }
 
 export interface vItem {
@@ -84,7 +87,7 @@ export interface vSyncItem extends vItem {
 }
 
 export interface vRecoveryItem extends vItem {
-	data: string;
+	data: string | ArrayBuffer;
 }
 
 export interface vGitItem extends vItem {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ const DEFAULT_SETTINGS: OpenSyncHistorySettings = {
 };
 
 export default class OpenSyncHistoryPlugin extends Plugin {
-	//@ts-ignore
+	//@ts-expect-error, initialized in loadSettings
 	settings: OpenSyncHistorySettings;
 	diff_utils = new DiffUtils(this, this.app);
 

--- a/src/recovery_diff_view.ts
+++ b/src/recovery_diff_view.ts
@@ -1,4 +1,4 @@
-import { App, TFile, Notice, sanitizeHTMLToDom } from 'obsidian';
+import { App, TFile, Notice } from 'obsidian';
 import type OpenSyncHistoryPlugin from './main';
 import type { recResult, vRecoveryItem } from './interfaces';
 import { FILE_REC_WARNING, ITEM_CLASS } from './constants';
@@ -18,9 +18,8 @@ export default class RecoveryDiffView extends DiffView {
 	async onOpen() {
 		super.onOpen();
 		await this.getInitialVersions();
-		const diff = this.getDiff();
 		this.makeHistoryLists(FILE_REC_WARNING);
-		this.basicHtml(diff as string, 'File Recovery Diff');
+		await this.basicHtml('File Recovery Diff');
 		this.appendVersions();
 		this.makeMoreGeneralHtml();
 	}
@@ -32,7 +31,12 @@ export default class RecoveryDiffView extends DiffView {
 			.transaction('backups', 'readonly')
 			.store.index('path')
 			.getAll();
-		const fileContent = await this.app.vault.read(this.file);
+		let fileContent: string | ArrayBuffer;
+		if (this.isBinaryFile()) {
+			fileContent = await this.app.vault.readBinary(this.file);
+		} else {
+			fileContent = await this.app.vault.read(this.file);
+		}
 		// correct date is calculated later
 		this.versions.push({ path: this.file.path, ts: 0, data: fileContent });
 		const len = fileRecovery.length - 1;
@@ -51,8 +55,12 @@ export default class RecoveryDiffView extends DiffView {
 		}
 
 		[this.leftContent, this.rightContent] = [
-			this.versions[1].data,
-			this.versions[0].data,
+			typeof this.versions[1].data === 'string'
+				? this.versions[1].data
+				: new Uint8Array(this.versions[1].data),
+			typeof this.versions[0].data === 'string'
+				? this.versions[0].data
+				: new Uint8Array(this.versions[0].data),
 		];
 	}
 
@@ -78,7 +86,7 @@ export default class RecoveryDiffView extends DiffView {
 	private appendRecoveryVersions(
 		el: HTMLElement,
 		versions: recResult[],
-		left: boolean = false
+		left = false
 	): vRecoveryItem[] {
 		const versionList: vRecoveryItem[] = [];
 		for (let i = 0; i < versions.length; i++) {
@@ -87,7 +95,7 @@ export default class RecoveryDiffView extends DiffView {
 			if (i === 0) {
 				date = new Date();
 			}
-			let div = el.createDiv({
+			const div = el.createDiv({
 				cls: ITEM_CLASS,
 				attr: {
 					id: left ? this.ids.left : this.ids.right,
@@ -115,18 +123,22 @@ export default class RecoveryDiffView extends DiffView {
 						this.leftActive,
 						left
 					)) as vRecoveryItem;
-					this.leftContent = version.data;
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(this.getDiff() as string));
+					this.leftContent =
+						typeof clickedEl.data === 'string'
+							? clickedEl.data
+							: new Uint8Array(clickedEl.data);
+					await this.updateDiffView();
 				} else {
 					const clickedEl = (await this.generateVersionListener(
 						div,
 						this.rightVList,
 						this.rightActive
 					)) as vRecoveryItem;
-					this.rightContent = version.data;
-					this.syncHistoryContentContainer.replaceChildren(
-						sanitizeHTMLToDom(this.getDiff() as string));
+					this.rightContent =
+						typeof clickedEl.data === 'string'
+							? clickedEl.data
+							: new Uint8Array(clickedEl.data);
+					await this.updateDiffView();
 				}
 			});
 		}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -593,3 +593,162 @@ mode from @SlRvb, which fall under the same license (MIT license, @kometenstaub 
 		}
 	}
 }
+
+.binary-diff {
+	display: flex;
+	flex-direction: row;
+	gap: 1.5rem;
+	width: 100%;
+	height: 100%;
+	min-height: 400px;
+	overflow: auto;
+
+	.binary-side {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 1.5rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		background-color: var(--background-primary-alt);
+		box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
+
+		h4 {
+			margin-top: 0;
+			margin-bottom: 1rem;
+			color: var(--text-normal);
+			font-weight: 600;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 60vh;
+			object-fit: contain;
+			box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+			border-radius: 4px;
+			background: repeating-conic-gradient(#555 0% 25%, #666 0% 50%) 50% /
+				20px 20px;
+		}
+
+		.binary-fallback-msg {
+			flex: 1;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			text-align: center;
+			color: var(--text-muted);
+			font-style: italic;
+			margin-bottom: 1rem;
+			padding: 2rem;
+			border: 2px dashed var(--background-modifier-border);
+			border-radius: 6px;
+			width: 100%;
+			max-width: 300px;
+		}
+	}
+}
+
+.diff-toggle-bar {
+	display: flex;
+	justify-content: center;
+	gap: 0.5rem;
+	padding: 0.5rem;
+	background-color: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	width: 100%;
+
+	.diff-toggle-btn {
+		padding: 0.25rem 0.75rem;
+		border-radius: 4px;
+		border: 1px solid var(--background-modifier-border);
+		background-color: var(--background-primary);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: var(--font-small);
+		transition: background-color 0.2s, color 0.2s;
+
+		&:hover {
+			background-color: var(--background-primary-alt);
+			color: var(--text-normal);
+		}
+
+		&.is-active {
+			background-color: var(--interactive-accent);
+			color: var(--text-on-accent);
+			border-color: var(--interactive-accent);
+		}
+	}
+}
+
+.sync-history-content-container.diff {
+	display: flex !important;
+	flex-direction: column !important;
+	overflow: hidden !important;
+}
+
+.diff-content-container-inner {
+	flex-grow: 1;
+	height: 100%;
+	width: 100%;
+	overflow: auto;
+}
+
+.markdown-rendered-diff {
+	display: flex;
+	flex-direction: row;
+	gap: 1.5rem;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+
+	.markdown-side {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		padding: 1.5rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		background-color: var(--background-primary);
+		box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.02);
+		overflow: auto;
+
+		h4 {
+			margin-top: 0;
+			margin-bottom: 1rem;
+			color: var(--text-normal);
+			font-weight: 600;
+			border-bottom: 1px solid var(--background-modifier-border);
+			padding-bottom: 0.5rem;
+		}
+
+		.rendered-content {
+			flex: 1;
+			color: var(--text-normal);
+			line-height: 1.6;
+			font-size: var(--font-normal);
+
+			p {
+				margin-bottom: 1em;
+			}
+
+			.diff-rendered-deleted {
+				background-color: var(--sync-delete-bg);
+				color: var(--text-normal);
+				padding: 0 2px;
+				border-radius: 2px;
+			}
+			del.diff-rendered-deleted {
+				text-decoration: line-through;
+			}
+
+			.diff-rendered-added {
+				background-color: var(--sync-insert-bg);
+				color: var(--text-normal);
+				text-decoration: none;
+				padding: 0 2px;
+				border-radius: 2px;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for binary file diffs, a toggle between rendered markdown and raw diff views, and some performance improvements to keep the UI responsive.

### Changes:
- **Binary files:** Added side-by-side previews for images (and fallback size info for other binary formats). Object URLs are properly revoked on close to prevent memory leaks.
- **View toggle:** Added a toggle bar to switch between the Rendered Markdown view and the Raw Diff view.
- **Performance:** 
  - Deferred heavy diff calculations using `setTimeout` so the UI paints instantly and doesn't freeze.
  - Set `matching: 'none'` in `diff2html` to avoid slow/expensive line matching on large files.
  - Added `drawFileList: false` to cleanly hide the redundant file header list.
- **Fixes:**
  - Fixed a context binding crash on `getContent` inside `diff_view.ts`.
  - Fixed unified diff parsing by restoring filenames in `createTwoFilesPatch` (which was causing blank raw views).
  - Resolved ESLint typing warnings in `global.d.ts`.
  
###  Issue Reference:
https://github.com/kometenstaub/obsidian-version-history-diff/issues/43

### Attached the reference output images:

<img width="1710" height="1112" alt="raw-diff-view" src="https://github.com/user-attachments/assets/faf1bbdf-7f73-404e-b7dd-562395dce04d" />
<img width="1710" height="1112" alt="rendered-diff-view" src="https://github.com/user-attachments/assets/3b1f2a09-1332-4612-a3dc-0842124c36db" />

